### PR TITLE
outline updates of /uni2C2F and /uni2C5F

### DIFF
--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs.public.background/contents.plist
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs.public.background/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>uni2C2F</key>
+    <string>uni2C_2F_.glif</string>
+  </dict>
+</plist>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs.public.background/uni2C_2F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs.public.background/uni2C_2F_.glif
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2C2F" format="2">
+  <advance width="648"/>
+  <unicode hex="2C2F"/>
+  <guideline x="-80" y="36"/>
+  <guideline x="324" y="792" angle="90"/>
+  <anchor x="324" y="927" name="top"/>
+  <outline>
+    <contour>
+      <point x="195" y="0" type="curve" smooth="yes"/>
+      <point x="453" y="0" type="line" smooth="yes"/>
+      <point x="531" y="0"/>
+      <point x="550" y="20"/>
+      <point x="550" y="98" type="curve" smooth="yes"/>
+      <point x="550" y="714" type="line"/>
+      <point x="460" y="714" type="line"/>
+      <point x="460" y="128" type="line" smooth="yes"/>
+      <point x="460" y="89"/>
+      <point x="451" y="79"/>
+      <point x="412" y="79" type="curve" smooth="yes"/>
+      <point x="236" y="79" type="line" smooth="yes"/>
+      <point x="197" y="79"/>
+      <point x="188" y="89"/>
+      <point x="188" y="128" type="curve" smooth="yes"/>
+      <point x="188" y="714" type="line"/>
+      <point x="98" y="714" type="line"/>
+      <point x="98" y="98" type="line" smooth="yes"/>
+      <point x="98" y="20"/>
+      <point x="117" y="0"/>
+    </contour>
+    <contour>
+      <point x="234" y="-299" type="curve" smooth="yes"/>
+      <point x="304" y="-299"/>
+      <point x="362" y="-253"/>
+      <point x="362" y="-164" type="curve" smooth="yes"/>
+      <point x="362" y="50" type="line"/>
+      <point x="287" y="50" type="line"/>
+      <point x="287" y="-168" type="line" smooth="yes"/>
+      <point x="287" y="-206"/>
+      <point x="266" y="-232"/>
+      <point x="234" y="-232" type="curve" smooth="yes"/>
+      <point x="207" y="-232"/>
+      <point x="188" y="-218"/>
+      <point x="188" y="-188" type="curve" smooth="yes"/>
+      <point x="188" y="-159"/>
+      <point x="208" y="-141"/>
+      <point x="251" y="-141" type="curve" smooth="yes"/>
+      <point x="494" y="-141" type="line"/>
+      <point x="494" y="-70" type="line"/>
+      <point x="253" y="-70" type="line" smooth="yes"/>
+      <point x="162" y="-70"/>
+      <point x="115" y="-121"/>
+      <point x="115" y="-188" type="curve" smooth="yes"/>
+      <point x="115" y="-252"/>
+      <point x="166" y="-299"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2024-08-15 12:50:47 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.leftMetricsKey</key>
+      <string>uni2C1E</string>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
+      <string>uni2C1E</string>
+      <key>public.markColor</key>
+      <string>0.67,0.95,0.38,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/contents.plist
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/contents.plist
@@ -204,6 +204,8 @@
     <string>uni2C_2D_.glif</string>
     <key>uni2C2E</key>
     <string>uni2C_2E_.glif</string>
+    <key>uni2C2F</key>
+    <string>uni2C_2F_.glif</string>
     <key>uni2C30</key>
     <string>uni2C_30.glif</string>
     <key>uni2C31</key>
@@ -298,6 +300,8 @@
     <string>uni2C_5D_.glif</string>
     <key>uni2C5E</key>
     <string>uni2C_5E_.glif</string>
+    <key>uni2C5F</key>
+    <string>uni2C_5F_.glif</string>
     <key>uniA66F</key>
     <string>uniA_66F_.glif</string>
   </dict>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/titlocomb-cy.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/titlocomb-cy.glif
@@ -2,8 +2,8 @@
 <glyph name="titlocomb-cy" format="2">
   <advance width="0"/>
   <unicode hex="0483"/>
-  <anchor x="-278" y="536" name="_top"/>
   <anchor x="-276" y="927" name="top"/>
+  <anchor x="-278" y="536" name="_top"/>
   <outline>
     <contour>
       <point x="-366" y="771" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_000.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_000.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E000" format="2">
   <advance width="0"/>
   <unicode hex="1E000"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-158" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_001.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_001.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E001" format="2">
   <advance width="0"/>
   <unicode hex="1E001"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-119" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_002.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_002.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E002" format="2">
   <advance width="0"/>
   <unicode hex="1E002"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-164" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_003.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_003.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E003" format="2">
   <advance width="0"/>
   <unicode hex="1E003"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-140" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_004.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_004.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E004" format="2">
   <advance width="0"/>
   <unicode hex="1E004"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-147" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_005.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_005.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E005" format="2">
   <advance width="0"/>
   <unicode hex="1E005"/>
-  <anchor x="-15" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="-15" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-35" y="601" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_006.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_006.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E006" format="2">
   <advance width="0"/>
   <unicode hex="1E006"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="976" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-164" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_008.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_008.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E008" format="2">
   <advance width="0"/>
   <unicode hex="1E008"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-189" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_009.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_009.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E009" format="2">
   <advance width="0"/>
   <unicode hex="1E009"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-67" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00A_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00A_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00A" format="2">
   <advance width="0"/>
   <unicode hex="1E00A"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-89" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00B_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00B_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00B" format="2">
   <advance width="0"/>
   <unicode hex="1E00B"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-91" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00C_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00C_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00C" format="2">
   <advance width="0"/>
   <unicode hex="1E00C"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-210" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00D_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00D_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00D" format="2">
   <advance width="0"/>
   <unicode hex="1E00D"/>
-  <anchor x="14" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="14" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="25" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00E_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00E_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00E" format="2">
   <advance width="0"/>
   <unicode hex="1E00E"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-164" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_00F_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E00F" format="2">
   <advance width="0"/>
   <unicode hex="1E00F"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-151" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_010.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_010.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E010" format="2">
   <advance width="0"/>
   <unicode hex="1E010"/>
-  <anchor x="-10" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="-10" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-94" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_011.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_011.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E011" format="2">
   <advance width="0"/>
   <unicode hex="1E011"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-41" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_012.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_012.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E012" format="2">
   <advance width="0"/>
   <unicode hex="1E012"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-140" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_013.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_013.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E013" format="2">
   <advance width="0"/>
   <unicode hex="1E013"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-54" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_014.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_014.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E014" format="2">
   <advance width="0"/>
   <unicode hex="1E014"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-91" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_015.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_015.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E015" format="2">
   <advance width="0"/>
   <unicode hex="1E015"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-164" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_016.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_016.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E016" format="2">
   <advance width="0"/>
   <unicode hex="1E016"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-104" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_017.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_017.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E017" format="2">
   <advance width="0"/>
   <unicode hex="1E017"/>
-  <anchor x="0" y="556" name="_top"/>
   <anchor x="0" y="976" name="top"/>
+  <anchor x="0" y="556" name="_top"/>
   <outline>
     <contour>
       <point x="-28" y="524" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_018.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_018.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E018" format="2">
   <advance width="0"/>
   <unicode hex="1E018"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-155" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01B_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01B_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E01B" format="2">
   <advance width="0"/>
   <unicode hex="1E01B"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-88" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01C_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01C_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E01C" format="2">
   <advance width="0"/>
   <unicode hex="1E01C"/>
-  <anchor x="53" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="53" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="34" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01D_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01D_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E01D" format="2">
   <advance width="0"/>
   <unicode hex="1E01D"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-88" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01E_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01E_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E01E" format="2">
   <advance width="0"/>
   <unicode hex="1E01E"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-119" y="605" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_01F_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E01F" format="2">
   <advance width="0"/>
   <unicode hex="1E01F"/>
-  <anchor x="53" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="53" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-31" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_020.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_020.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E020" format="2">
   <advance width="0"/>
   <unicode hex="1E020"/>
-  <anchor x="48" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="48" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-37" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_021.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_021.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E021" format="2">
   <advance width="0"/>
   <unicode hex="1E021"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-179" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_023.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_023.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E023" format="2">
   <advance width="0"/>
   <unicode hex="1E023"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-158" y="571" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_024.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_024.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E024" format="2">
   <advance width="0"/>
   <unicode hex="1E024"/>
-  <anchor x="19" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="19" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="59" y="601" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_026.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_026.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E026" format="2">
   <advance width="0"/>
   <unicode hex="1E026"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-90" y="605" type="line"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_027.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_027.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E027" format="2">
   <advance width="0"/>
   <unicode hex="1E027"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-144" y="601" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_028.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_028.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E028" format="2">
   <advance width="0"/>
   <unicode hex="1E028"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="152" y="601" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_02A_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/u1E_02A_.glif
@@ -2,8 +2,8 @@
 <glyph name="u1E02A" format="2">
   <advance width="0"/>
   <unicode hex="1E02A"/>
-  <anchor x="0" y="605" name="_top"/>
   <anchor x="0" y="908" name="top"/>
+  <anchor x="0" y="605" name="_top"/>
   <outline>
     <contour>
       <point x="-1" y="601" type="curve" smooth="yes"/>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_1B_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_1B_.glif
@@ -41,9 +41,9 @@
       <point x="227" y="193" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="316" y="79" type="line"/>
-      <point x="316" y="193" type="line" smooth="yes"/>
-      <point x="316" y="291"/>
+      <point x="317" y="79" type="line"/>
+      <point x="317" y="193" type="line" smooth="yes"/>
+      <point x="317" y="291"/>
       <point x="329" y="333"/>
       <point x="409" y="333" type="curve" smooth="yes"/>
       <point x="490" y="333"/>
@@ -55,7 +55,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2022-06-21 15:51:42 +0000</string>
+      <string>2024-08-08 18:59:15 +0000</string>
     </dict>
   </lib>
 </glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_1F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_1F_.glif
@@ -78,7 +78,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2022-06-21 15:52:12 +0000</string>
+      <string>2024-08-08 19:26:17 +0000</string>
     </dict>
   </lib>
 </glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_20.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_20.glif
@@ -64,7 +64,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2022-06-21 15:52:18 +0000</string>
+      <string>2024-08-08 19:26:26 +0000</string>
     </dict>
   </lib>
 </glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_2F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_2F_.glif
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2C2F" format="2">
+  <advance width="648"/>
+  <unicode hex="2C2F"/>
+  <guideline x="-80" y="36"/>
+  <guideline x="324" y="792" angle="90"/>
+  <anchor x="324" y="927" name="top"/>
+  <outline>
+    <contour>
+      <point x="195" y="0" type="curve" smooth="yes"/>
+      <point x="453" y="0" type="line" smooth="yes"/>
+      <point x="531" y="0"/>
+      <point x="550" y="20"/>
+      <point x="550" y="98" type="curve" smooth="yes"/>
+      <point x="550" y="714" type="line"/>
+      <point x="460" y="714" type="line"/>
+      <point x="460" y="128" type="line" smooth="yes"/>
+      <point x="460" y="89"/>
+      <point x="451" y="79"/>
+      <point x="412" y="79" type="curve" smooth="yes"/>
+      <point x="236" y="79" type="line" smooth="yes"/>
+      <point x="197" y="79"/>
+      <point x="188" y="89"/>
+      <point x="188" y="128" type="curve" smooth="yes"/>
+      <point x="188" y="714" type="line"/>
+      <point x="98" y="714" type="line"/>
+      <point x="98" y="98" type="line" smooth="yes"/>
+      <point x="98" y="20"/>
+      <point x="117" y="0"/>
+    </contour>
+    <contour>
+      <point x="234" y="-299" type="curve" smooth="yes"/>
+      <point x="304" y="-299"/>
+      <point x="362" y="-253"/>
+      <point x="362" y="-164" type="curve" smooth="yes"/>
+      <point x="362" y="50" type="line"/>
+      <point x="287" y="50" type="line"/>
+      <point x="287" y="-168" type="line" smooth="yes"/>
+      <point x="287" y="-206"/>
+      <point x="266" y="-232"/>
+      <point x="234" y="-232" type="curve" smooth="yes"/>
+      <point x="207" y="-232"/>
+      <point x="188" y="-218"/>
+      <point x="188" y="-188" type="curve" smooth="yes"/>
+      <point x="188" y="-159"/>
+      <point x="208" y="-141"/>
+      <point x="251" y="-141" type="curve" smooth="yes"/>
+      <point x="494" y="-141" type="line"/>
+      <point x="494" y="-70" type="line"/>
+      <point x="253" y="-70" type="line" smooth="yes"/>
+      <point x="162" y="-70"/>
+      <point x="115" y="-121"/>
+      <point x="115" y="-188" type="curve" smooth="yes"/>
+      <point x="115" y="-252"/>
+      <point x="166" y="-299"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2024-08-15 12:50:47 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.leftMetricsKey</key>
+      <string>uni2C1E</string>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
+      <string>uni2C1E</string>
+      <key>public.markColor</key>
+      <string>0.67,0.95,0.38,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_5F_.glif
+++ b/sources/NotoSansGlagolitic-Regular.ufo/glyphs/uni2C_5F_.glif
@@ -1,0 +1,68 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2C5F" format="2">
+  <advance width="565"/>
+  <unicode hex="2C5F"/>
+  <anchor x="283" y="927" name="top"/>
+  <outline>
+    <contour>
+      <point x="210" y="-251" type="curve" smooth="yes"/>
+      <point x="276" y="-251"/>
+      <point x="315" y="-205"/>
+      <point x="315" y="-140" type="curve" smooth="yes"/>
+      <point x="315" y="41" type="line"/>
+      <point x="250" y="41" type="line"/>
+      <point x="250" y="-140" type="line" smooth="yes"/>
+      <point x="250" y="-170"/>
+      <point x="238" y="-193"/>
+      <point x="211" y="-193" type="curve" smooth="yes"/>
+      <point x="190" y="-193"/>
+      <point x="176" y="-181"/>
+      <point x="176" y="-159" type="curve" smooth="yes"/>
+      <point x="176" y="-135"/>
+      <point x="193" y="-125"/>
+      <point x="214" y="-125" type="curve" smooth="yes"/>
+      <point x="427" y="-125" type="line"/>
+      <point x="427" y="-65" type="line"/>
+      <point x="222" y="-65" type="line" smooth="yes"/>
+      <point x="151" y="-65"/>
+      <point x="113" y="-105"/>
+      <point x="113" y="-158" type="curve" smooth="yes"/>
+      <point x="113" y="-207"/>
+      <point x="144" y="-251"/>
+    </contour>
+    <contour>
+      <point x="155" y="0" type="curve" smooth="yes"/>
+      <point x="410" y="0" type="line" smooth="yes"/>
+      <point x="473" y="0"/>
+      <point x="477" y="29"/>
+      <point x="477" y="88" type="curve" smooth="yes"/>
+      <point x="477" y="536" type="line"/>
+      <point x="391" y="536" type="line"/>
+      <point x="391" y="110" type="line" smooth="yes"/>
+      <point x="391" y="81"/>
+      <point x="386" y="71"/>
+      <point x="357" y="71" type="curve" smooth="yes"/>
+      <point x="208" y="71" type="line" smooth="yes"/>
+      <point x="179" y="71"/>
+      <point x="174" y="81"/>
+      <point x="174" y="110" type="curve" smooth="yes"/>
+      <point x="174" y="536" type="line"/>
+      <point x="88" y="536" type="line"/>
+      <point x="88" y="88" type="line" smooth="yes"/>
+      <point x="88" y="29"/>
+      <point x="92" y="0"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2024-08-15 12:50:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.leftMetricsKey</key>
+      <string>uni2C4E</string>
+      <key>com.schriftgestaltung.Glyphs.rightMetricsKey</key>
+      <string>uni2C4E</string>
+      <key>public.markColor</key>
+      <string>0.67,0.95,0.38,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/NotoSansGlagolitic-Regular.ufo/layercontents.plist
+++ b/sources/NotoSansGlagolitic-Regular.ufo/layercontents.plist
@@ -6,5 +6,9 @@
       <string>public.default</string>
       <string>glyphs</string>
     </array>
+    <array>
+      <string>public.background</string>
+      <string>glyphs.public.background</string>
+    </array>
   </array>
 </plist>

--- a/sources/NotoSansGlagolitic-Regular.ufo/lib.plist
+++ b/sources/NotoSansGlagolitic-Regular.ufo/lib.plist
@@ -4,18 +4,166 @@
   <dict>
     <key>com.schriftgestaltung.DisplayStrings</key>
     <array>
-      <string>̅ </string>
-      <string>Ⱗ</string>
-      <string>Ⰶ︮</string>
+      <string>ⰐⰑⰓⰗⰦⰫⰯ</string>
+      <string>ⰞⱀⱎⱟⰯ</string>
+      <string>Ⱟ</string>
     </array>
+    <key>com.schriftgestaltung.appVersion</key>
+    <string>3315</string>
     <key>com.schriftgestaltung.disablesAutomaticAlignment</key>
     <false/>
     <key>com.schriftgestaltung.fontMasterID</key>
     <string>UUID0</string>
     <key>com.schriftgestaltung.formatVersion</key>
     <integer>3</integer>
-    <key>com.schriftgestaltung.useGlyphOrder</key>
-    <true/>
+    <key>com.schriftgestaltung.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>NULL</string>
+      <string>CR</string>
+      <string>space</string>
+      <string>uni00A0</string>
+      <string>tildecomb</string>
+      <string>uni0305</string>
+      <string>uni0484</string>
+      <string>uni0487</string>
+      <string>uni2C00</string>
+      <string>uni2C01</string>
+      <string>uni2C02</string>
+      <string>uni2C03</string>
+      <string>uni2C04</string>
+      <string>uni2C05</string>
+      <string>uni2C06</string>
+      <string>uni2C07</string>
+      <string>uni2C08</string>
+      <string>uni2C09</string>
+      <string>uni2C0A</string>
+      <string>uni2C0B</string>
+      <string>uni2C0C</string>
+      <string>uni2C0D</string>
+      <string>uni2C0E</string>
+      <string>uni2C0F</string>
+      <string>uni2C10</string>
+      <string>uni2C11</string>
+      <string>uni2C12</string>
+      <string>uni2C13</string>
+      <string>uni2C14</string>
+      <string>uni2C15</string>
+      <string>uni2C16</string>
+      <string>uni2C17</string>
+      <string>uni2C18</string>
+      <string>uni2C19</string>
+      <string>uni2C1A</string>
+      <string>uni2C1B</string>
+      <string>uni2C1C</string>
+      <string>uni2C1D</string>
+      <string>uni2C1E</string>
+      <string>uni2C1F</string>
+      <string>uni2C20</string>
+      <string>uni2C21</string>
+      <string>uni2C22</string>
+      <string>uni2C23</string>
+      <string>uni2C24</string>
+      <string>uni2C25</string>
+      <string>uni2C26</string>
+      <string>uni2C27</string>
+      <string>uni2C28</string>
+      <string>uni2C29</string>
+      <string>uni2C2A</string>
+      <string>uni2C2B</string>
+      <string>uni2C2C</string>
+      <string>uni2C2D</string>
+      <string>uni2C2E</string>
+      <string>uni2C2F</string>
+      <string>uni2C30</string>
+      <string>uni2C31</string>
+      <string>uni2C32</string>
+      <string>uni2C33</string>
+      <string>uni2C34</string>
+      <string>uni2C35</string>
+      <string>uni2C36</string>
+      <string>uni2C37</string>
+      <string>uni2C38</string>
+      <string>uni2C39</string>
+      <string>uni2C3A</string>
+      <string>uni2C3B</string>
+      <string>uni2C3C</string>
+      <string>uni2C3D</string>
+      <string>uni2C3E</string>
+      <string>uni2C3F</string>
+      <string>uni2C40</string>
+      <string>uni2C41</string>
+      <string>uni2C42</string>
+      <string>uni2C43</string>
+      <string>uni2C44</string>
+      <string>uni2C45</string>
+      <string>uni2C46</string>
+      <string>uni2C47</string>
+      <string>uni2C48</string>
+      <string>uni2C49</string>
+      <string>uni2C4A</string>
+      <string>uni2C4B</string>
+      <string>uni2C4C</string>
+      <string>uni2C4D</string>
+      <string>uni2C4E</string>
+      <string>uni2C4F</string>
+      <string>uni2C50</string>
+      <string>uni2C51</string>
+      <string>uni2C52</string>
+      <string>uni2C53</string>
+      <string>uni2C54</string>
+      <string>uni2C55</string>
+      <string>uni2C56</string>
+      <string>uni2C57</string>
+      <string>uni2C58</string>
+      <string>uni2C59</string>
+      <string>uni2C5A</string>
+      <string>uni2C5B</string>
+      <string>uni2C5C</string>
+      <string>uni2C5D</string>
+      <string>uni2C5E</string>
+      <string>uni2C5F</string>
+      <string>uni2E43</string>
+      <string>uniA66F</string>
+      <string>u1E000</string>
+      <string>u1E001</string>
+      <string>u1E002</string>
+      <string>u1E003</string>
+      <string>u1E004</string>
+      <string>u1E005</string>
+      <string>u1E006</string>
+      <string>u1E008</string>
+      <string>u1E009</string>
+      <string>u1E00A</string>
+      <string>u1E00B</string>
+      <string>u1E00C</string>
+      <string>u1E00D</string>
+      <string>u1E00E</string>
+      <string>u1E00F</string>
+      <string>u1E010</string>
+      <string>u1E011</string>
+      <string>u1E012</string>
+      <string>u1E013</string>
+      <string>u1E014</string>
+      <string>u1E015</string>
+      <string>u1E016</string>
+      <string>u1E017</string>
+      <string>u1E018</string>
+      <string>u1E01B</string>
+      <string>u1E01C</string>
+      <string>u1E01D</string>
+      <string>u1E01E</string>
+      <string>u1E01F</string>
+      <string>u1E020</string>
+      <string>u1E021</string>
+      <string>u1E023</string>
+      <string>u1E024</string>
+      <string>u1E026</string>
+      <string>u1E027</string>
+      <string>u1E028</string>
+      <string>u1E029</string>
+      <string>u1E02A</string>
+    </array>
     <key>com.schriftgestaltung.useNiceNames</key>
     <false/>
     <key>public.glyphOrder</key>
@@ -76,6 +224,7 @@
       <string>uni2C2C</string>
       <string>uni2C2D</string>
       <string>uni2C2E</string>
+      <string>uni2C2F</string>
       <string>uni2C30</string>
       <string>uni2C31</string>
       <string>uni2C32</string>
@@ -123,6 +272,7 @@
       <string>uni2C5C</string>
       <string>uni2C5D</string>
       <string>uni2C5E</string>
+      <string>uni2C5F</string>
       <string>uni2E43</string>
       <string>uniA66F</string>
       <string>u1E000</string>
@@ -163,6 +313,13 @@
       <string>u1E028</string>
       <string>u1E029</string>
       <string>u1E02A</string>
+      <string>uni25CC</string>
+      <string>titlocomb-cy</string>
+      <string>titlolefthalfcomb-cy</string>
+      <string>titlorighthalfcomb-cy</string>
+      <string>conjoiningmacroncomb</string>
+      <string>macronlefthalfcomb</string>
+      <string>macronrighthalfcomb</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>


### PR DESCRIPTION
The following glyphs added to the source:
- GLAGOLITIC CAPITAL LETTER CAUDATE CHRIVI (U+2C2F)
- GLAGOLITIC SMALL LETTER CAUDATE CHRIVI (U+2C5F) 

The new glyphs include 'top' anchors to support positioning for Gagolitic's combining characters.
The New code-points have also been added to the glyphOrder Custom Parameter.  